### PR TITLE
Optionally not update TTL on Get()

### DIFF
--- a/ttlru.go
+++ b/ttlru.go
@@ -27,11 +27,12 @@ type entry struct {
 
 // Cache is the type that implements the ttlru
 type Cache struct {
-	cap   int
-	ttl   time.Duration
-	items map[interface{}]*entry
-	heap  *ttlHeap
-	lock  sync.RWMutex
+	cap     int
+	ttl     time.Duration
+	items   map[interface{}]*entry
+	heap    *ttlHeap
+	lock    sync.RWMutex
+	NoReset bool
 }
 
 // New creates a new Cache with cap entries that expire after ttl has
@@ -144,7 +145,9 @@ func (c *Cache) Get(key interface{}) (interface{}, bool) {
 		// the item should be automatically removed when it expires, but we
 		// check just to be safe
 		if time.Now().Before(ent.expires) {
-			c.resetEntryTTL(ent)
+			if c.NoReset != true {
+				c.resetEntryTTL(ent)
+			}
 			return ent.value, true
 		}
 	}

--- a/ttlru_test.go
+++ b/ttlru_test.go
@@ -139,5 +139,34 @@ func TestTTL(t *testing.T) {
 			So(l.Del(1), ShouldBeTrue)
 			So(l.Del(2), ShouldBeFalse)
 		})
+
+		Convey("Item should expired despite Get()", func() {
+			l := New(1, 300*time.Millisecond)
+			So(l, ShouldNotBeNil)
+			So(l.Set(1, 1), ShouldBeFalse)
+			l.NoReset = true
+
+			done := make(chan interface{})
+			time.AfterFunc(200*time.Millisecond, func() {
+				Convey("Get() item works", t, func() {
+					v, ok := l.Get(1)
+					So(ok, ShouldBeTrue)
+					So(v, ShouldEqual, 1)
+					done <- true
+				})
+			})
+			<-done
+
+			time.AfterFunc(200*time.Millisecond, func() {
+				Convey("Item is gone despite the Get()", t, func() {
+					v, ok := l.Get(1)
+					So(ok, ShouldBeFalse)
+					So(v, ShouldBeNil)
+					done <- true
+				})
+			})
+			<-done
+
+		})
 	})
 }


### PR DESCRIPTION
I needed a cache that invalidates keys even if I keep fetching them. Added a flag to the struct. Feel free to reject if the use case is too specific.
