### PR TITLE
Purge() resets index on existing entries.

### DIFF
--- a/ttlru.go
+++ b/ttlru.go
@@ -228,6 +228,10 @@ func (c *cache) Purge() {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
+	for _, e := range c.items {
+		e.index = -1
+	}
+
 	h := make(ttlHeap, 0, c.cap)
 	c.heap = &h
 	c.items = make(map[interface{}]*entry, c.cap)


### PR DESCRIPTION
This prevents a panic when using TTLs when an entry's expiration go
routine wakes up and tries to manipulate indexes refering to a heap that
no longer necessarily exists.

Fixes #5 