### PR TITLE
Bug Fix: TTL at Capacity

### DIFF
--- a/ttlru.go
+++ b/ttlru.go
@@ -176,6 +176,11 @@ func (c *cache) removeEntry(e *entry) {
 		heap.Remove(c.heap, e.index)
 	}
 
+	// if a ttl was set, stop the timer to avoid leaking timers
+	if e.timer != nil {
+		e.timer.Stop()
+	}
+
 	// delete the item from the map
 	delete(c.items, e.key)
 }

--- a/ttlru_test.go
+++ b/ttlru_test.go
@@ -223,3 +223,26 @@ func TestPopEmptyHeap(t *testing.T) {
 
 	heap.Pop(&h)
 }
+
+func TestFullCacheTTLEviction(t *testing.T) {
+	// Test that when an item with TTL is evicted, the TTL timer is cancelled
+	// Otherwise, the key will be deleted earlier than it should
+	l := New(5, WithTTL(1*time.Second))
+
+	for i := 0; i < 6; i++ {
+		l.Set(i, "test")
+		if i == 0 {
+			time.Sleep(500 * time.Millisecond)
+		}
+	}
+
+	// 0 should have been evicted
+	_, ok := l.Get(0)
+	require.False(t, ok)
+	// add 0 back in
+	l.Set(0, "test")
+	time.Sleep(500 * time.Millisecond)
+	// 0 should still be there
+	_, ok = l.Get(0)
+	require.True(t, ok)
+}


### PR DESCRIPTION
This fixes 2 issues that occur when TTL is enabled, and the cache is at capacity. 

- Keys that have been evicted that are again re-added are removed early because the background removal timer is still alive from the previous entry. 
- With a long TTL, the leaked timers build up over time, presenting as a memory leak.

The fix is to stop the timer within `removeEntry` if one was set. 

I added a unit test that reproduces this bug and verifies the fix.

We've pull this fix into our production code and have verified. 